### PR TITLE
Use the sources from PyPI (v0.0.18)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ test:
     # has linux native library imports  # [not win]
     - skbeam.ext.ctrans  # [not win]
   requires:
+    - nose
     - pytest
   commands:
     - pytest -vvvv $SP_DIR/skbeam/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,8 @@ test:
     - nose
     - pytest
   commands:
-    - pytest -vvvv {{ SP_DIR }}/skbeam/
+    - pytest -vvvv $SP_DIR/skbeam/  # [not win]
+    - pytest -vvvv %SP_DIR%\skbeam\  # [win]
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,8 @@ test:
     - pytest
   commands:
     - pytest -vvvv $SP_DIR/skbeam/  # [not win]
-    - pytest -vvvv %SP_DIR%\skbeam\  # [win]
+    # Skipping full testing on Windows for now due to the known issue with ctrans (#418)
+    # - pytest -vvvv %SP_DIR%\skbeam\  # [win]
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "scikit-beam" %}
-{% set version = "0.0.17" %}
-{% set sha256 = "a6f73188d427d0a10bd1d21a8377ce794f15107e1c3a202b266c52727d8e37ad" %}
+{% set version = "0.0.18" %}
+{% set sha256 = "91dbb898d6103c08a8e1c08b22dc8a060daf395664c09c50b88f801d9aeb83ec" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<36]
   script:
     - python setup.py build_ext -i

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,6 @@ requirements:
     - {{ pin_compatible('numpy') }}
 
 test:
-  requires:
-    - pytest
   imports:
     - skbeam
     - skbeam.io
@@ -52,8 +50,12 @@ test:
     - skbeam.core.constants.xrf
     # has linux native library imports  # [not win]
     - skbeam.ext.ctrans  # [not win]
+  requires:
+    - pytest
+  source_files:
+    - test*.py
   commands:
-    - pytest -vvvv skbeam/
+    - pytest -vvvv --pyargs skbeam.tests
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - python
     - fabio
     - lmfit >=0.8.3
+    - pyfai
     - scikit-image
     - scipy
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ test:
     # has linux native library imports  # [not win]
     - skbeam.ext.ctrans  # [not win]
   commands:
-    - pytest -vvvv
+    - pytest -vvvv skbeam/
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - six
   run:
     - python
+    - fabio
     - lmfit >=0.8.3
     - scikit-image
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,10 +52,8 @@ test:
     - skbeam.ext.ctrans  # [not win]
   requires:
     - pytest
-  source_files:
-    - test*.py
   commands:
-    - pytest -vvvv $PREFIX/lib/python3.6/site-packages/skbeam/
+    - pytest -vvvv $SP_DIR/skbeam/
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
     - nose
     - pytest
   commands:
-    - pytest -vvvv $SP_DIR/skbeam/
+    - pytest -vvvv {{ SP_DIR }}/skbeam/
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ test:
   source_files:
     - test*.py
   commands:
-    - pytest -vvvv --pyargs skbeam.tests
+    - pytest -vvvv $PREFIX/lib/python3.6/site-packages/skbeam/
 
 about:
   home: http://scikit-beam.github.io/scikit-beam

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "scikit-beam" %}
 {% set version = "0.0.17" %}
-{% set sha256 = "2c59dab3b6058e6e61df5d5fd95b49518ee196c9b572f2885b6fbf8eec58cb42" %}
+{% set sha256 = "a6f73188d427d0a10bd1d21a8377ce794f15107e1c3a202b266c52727d8e37ad" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<36]
   script:
     - python setup.py build_ext -i

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ requirements:
     - {{ pin_compatible('numpy') }}
 
 test:
+  requires:
+    - pytest
   imports:
     - skbeam
     - skbeam.io
@@ -50,6 +52,8 @@ test:
     - skbeam.core.constants.xrf
     # has linux native library imports  # [not win]
     - skbeam.ext.ctrans  # [not win]
+  commands:
+    - pytest -vvvv
 
 about:
   home: http://scikit-beam.github.io/scikit-beam


### PR DESCRIPTION
From https://pypi.org/project/scikit-beam/0.0.17/#files.

Closes #5 (`pytest`s in `meta.yaml` for Linux/OSX, Windows will be addressed later via https://github.com/scikit-beam/scikit-beam/pull/467 or another project issue/PR).